### PR TITLE
feat: add websocket notifications

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { NotificationBadge } from './NotificationBadge';
 
 const NavItem: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <a href="#" className="text-gray-300 hover:text-white transition-colors duration-200 text-sm font-medium">
@@ -35,9 +36,12 @@ export const Header: React.FC = () => {
         <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-white cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
         </svg>
-        <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-white cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
-        </svg>
+        <div className="relative">
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-white cursor-pointer" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+          </svg>
+          <NotificationBadge />
+        </div>
         <img src="https://picsum.photos/seed/user-avatar/40/40" alt="User Avatar" className="w-8 h-8 rounded" />
       </div>
     </header>

--- a/components/NotificationBadge.tsx
+++ b/components/NotificationBadge.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useNotifications } from './NotificationProvider';
+
+export const NotificationBadge: React.FC = () => {
+  const { notifications } = useNotifications();
+  const count = notifications.length;
+  if (count === 0) return null;
+  return (
+    <span className="absolute -top-1 -right-1 bg-red-600 text-white text-xs rounded-full px-1">
+      {count}
+    </span>
+  );
+};

--- a/components/NotificationProvider.tsx
+++ b/components/NotificationProvider.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { NotificationEvent, notificationService } from '../services/notificationService';
+import { NotificationToast } from './NotificationToast';
+
+interface NotificationContextValue {
+  notifications: NotificationEvent[];
+}
+
+const NotificationContext = createContext<NotificationContextValue>({ notifications: [] });
+
+export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [notifications, setNotifications] = useState<NotificationEvent[]>(() => notificationService.getPersisted());
+
+  useEffect(() => {
+    notificationService.connect();
+    notificationService.subscribe((n) => {
+      setNotifications((prev) => [...prev, n]);
+    });
+  }, []);
+
+  const latest = notifications[notifications.length - 1];
+
+  return (
+    <NotificationContext.Provider value={{ notifications }}>
+      {children}
+      <NotificationToast notification={latest} />
+    </NotificationContext.Provider>
+  );
+};
+
+export const useNotifications = () => useContext(NotificationContext);

--- a/components/NotificationToast.tsx
+++ b/components/NotificationToast.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { NotificationEvent } from '../services/notificationService';
+
+interface Props {
+  notification?: NotificationEvent;
+}
+
+export const NotificationToast: React.FC<Props> = ({ notification }) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (notification) {
+      setVisible(true);
+      const timer = setTimeout(() => setVisible(false), 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [notification]);
+
+  if (!notification || !visible) return null;
+
+  const message =
+    notification.type === 'new_comment'
+      ? 'New comment received'
+      : 'Your post got a new like';
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow-lg">
+      {message}
+    </div>
+  );
+};

--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { NotificationProvider } from './components/NotificationProvider';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -11,6 +12,8 @@ if (!rootElement) {
 const root = ReactDOM.createRoot(rootElement);
 root.render(
   <React.StrictMode>
-    <App />
+    <NotificationProvider>
+      <App />
+    </NotificationProvider>
   </React.StrictMode>
 );

--- a/services/notificationService.ts
+++ b/services/notificationService.ts
@@ -1,0 +1,50 @@
+export type NotificationEvent = {
+  type: 'new_comment' | 'new_like';
+  [key: string]: any;
+};
+
+export type NotificationCallback = (notification: NotificationEvent) => void;
+
+class NotificationService {
+  private socket: WebSocket | null = null;
+  private callbacks: NotificationCallback[] = [];
+
+  connect(url: string = 'ws://localhost:8080'): void {
+    if (this.socket) return;
+    this.socket = new WebSocket(url);
+    this.socket.onmessage = (event: MessageEvent) => {
+      try {
+        const data: NotificationEvent = JSON.parse(event.data);
+        this.callbacks.forEach(cb => cb(data));
+        this.persist(data);
+      } catch (err) {
+        console.error('Failed to parse notification', err);
+      }
+    };
+  }
+
+  subscribe(cb: NotificationCallback): void {
+    this.callbacks.push(cb);
+  }
+
+  private persist(notification: NotificationEvent): void {
+    try {
+      const existing = this.getPersisted();
+      existing.push({ ...notification, timestamp: Date.now() });
+      localStorage.setItem('notifications', JSON.stringify(existing));
+    } catch (err) {
+      console.error('Failed to persist notification', err);
+    }
+  }
+
+  getPersisted(): NotificationEvent[] {
+    try {
+      const raw = localStorage.getItem('notifications');
+      return raw ? JSON.parse(raw) : [];
+    } catch {
+      return [];
+    }
+  }
+}
+
+export const notificationService = new NotificationService();


### PR DESCRIPTION
## Summary
- add notification service with websocket support and local storage persistence
- show latest notification via toast and count badge
- wrap app in notification provider

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b746edff18832ba038d7dd3f148de6