### PR TITLE
Add WebSocket disconnect and reconnection handling

### DIFF
--- a/components/NotificationProvider.tsx
+++ b/components/NotificationProvider.tsx
@@ -16,6 +16,7 @@ export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({ 
     notificationService.subscribe((n) => {
       setNotifications((prev) => [...prev, n]);
     });
+    return () => notificationService.disconnect();
   }, []);
 
   const latest = notifications[notifications.length - 1];


### PR DESCRIPTION
## Summary
- handle WebSocket errors and closed connections with optional reconnect
- expose and use a disconnect method in NotificationProvider

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbd4e418f0832b94e18a4e55b5315b